### PR TITLE
Fix CI cache restoration issue

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/walles/moor/v2
 
-go 1.23
+go 1.23.12
 
 toolchain go1.24.4
 


### PR DESCRIPTION
By bumping Go to a newer 1.23 version:
https://github.com/actions/setup-go/issues/498#issuecomment-2343521480
