### PR TITLE
Stop --quit-if-one-screen from flashing on highlighted input

### DIFF
--- a/STARTUP-TUNING.md
+++ b/STARTUP-TUNING.md
@@ -272,6 +272,15 @@ not a reason to keep this file around.
   `twin/fake-screen.go:104`. It is not part of the `Screen` interface, no
   `UnixScreen` counterpart exists, and nothing calls it. Deletable as is.
 
+- **`go test -count=5 ./internal/` fails `TestSearchHighlight` 4 times out of
+  5.** `internal/screenLines_test.go:126`. The package level style variables in
+  `internal/styling.go:15-29` are set up by `styleUI()` and never reset, so a
+  test that runs after one which styled the UI sees the styles the other test
+  left behind. Only the second and later runs of a `-count=N` are affected, so
+  CI never sees it, but it does mean `-count=N` is not a usable flakiness check
+  for this package. Predates this effort, and the same globals are why the tests
+  added for step 7 stop their pagers when they are done.
+
 - **`FakeScreen.Events()` returns nil, with a `TODO` on it.**
   `twin/fake-screen.go:112-115`. `<-nil` blocks forever, so no test using a
   plain `FakeScreen` can run the pager main loop, which is a large hole given

--- a/STARTUP-TUNING.md
+++ b/STARTUP-TUNING.md
@@ -172,7 +172,7 @@ One branch per step, each merged into master separately.
       colored line makes it obvious, which is what
       `TestReprintEndsWithStyleReset` pages.
 
-- [ ] **7. Close the highlighting race for file arguments.**
+- [ ] **7. Close the highlighting race.**
       `moor --quit-if-one-screen foo.go` still blinks, measured 7/15 on a 20
       line `.go` file. `HighlightingDone` is only preset at construction when
       there is no lexer (`internal/reader/constructors.go:56-58`), which is why
@@ -181,27 +181,64 @@ One branch per step, each merged into master separately.
       `cmd/moor/moor.go:602`, a few hundred microseconds before the main loop
       starts, and then loses the race about half the time. The margin is
       30-370 µs.
+      Pipes are in scope too, not just file arguments: `NewFromStream`
+      (`internal/reader/constructors.go:80-98`) doesn't preset
+      `HighlightingDone` either. Piped plain text only wins the race because
+      `highlightFromMemory` bails out early
+      (`internal/reader/highlight.go:144-155`). Piped JSON, and anything
+      `enry.GetLanguage()` classifies, race exactly like a `.go` file argument.
       This one needs no invented number, which is why it is not part of step 8:
-      waiting for `HighlightingDone` when the decision is otherwise ready would
-      be deterministic. But highlighting covers the whole input, not just the
-      part that would fit, so the wait needs a `GetLineCount() > height` gate in
-      front of it or a huge file stalls the first paint. That gate lives here,
-      and step 8 reuses it.
-      A gate on the pre-highlighting line count is safe in both directions.
-      Highlighting can only make the count grow (`ShouldFormat` reformats JSON),
-      so anything already too tall to fit stays too tall, and anything short
-      enough to pass the gate is small enough that waiting for it is cheap.
+      the decision is otherwise ready, so all that is missing is holding the
+      first paint until highlighting lands. Don't block the main loop waiting
+      for it. Skip the `p.redraw()` instead and fall through to
+      `event := <-screen.Events()`: `HighlightingDone.Store(true)` is followed
+      by a `MaybeDone` signal (`internal/reader/consumer.go:42-46`), the
+      goroutine at `internal/pager.go:641-643` turns that into an event, and
+      both channels are buffered so the wakeup cannot be dropped. Keys stay live
+      and the reader needs no new API. Re-evaluate every lap rather than holding
+      exactly one frame: `highlightFromMemory` signals `MoreLinesAdded` before
+      `HighlightingDone`, so waking up with highlighting still pending is
+      normal.
+      The gate is `p.fitsOnOneScreen()` itself: hold only when the decision
+      would otherwise have said yes and highlighting is the one thing left. It
+      is already the inner test at `internal/pager.go:670`, so this is a swap,
+      moving it out into the outer condition and leaving `HighlightingDone`
+      inside. That adds no new predicate, where the `GetLineCount() > height`
+      gate this step first called for would have inlined a copy of
+      `fitsOnOneScreen()`'s own first lines (`internal/pager.go:819-821`),
+      giving two places to drift apart. Extract the whole condition as
+      `shouldHoldFirstPaint()`; step 8 reuses it and wants one place to extend.
+      Highlighting completing is not actually guaranteed: a panic in the reader
+      goroutine is only logged (`internal/reader/panicHandler.go:9-18`), leaving
+      `HighlightingDone` false forever. So add a `sawUserInput` flag, set in the
+      key/rune/mouse cases at `internal/pager.go:696-705`, and never hold once
+      it is set. That bounds a panicked reader to a blank screen until the user
+      touches something rather than a hang, and step 8 wants the same condition
+      anyway. Worth a separate commit: have the deferred handler at
+      `internal/reader/constructors.go:157-163` mark reading and highlighting
+      done, which also fixes the forever-spinning spinner a panic leaves behind.
       `MOOR=--quit-if-one-screen` plus a source file is a mainstream invocation,
       so this is the more valuable of the two remaining steps.
       Note that `p.redraw()` is unconditional once the check declines, so
-      nothing currently holds the first paint back.
+      nothing currently holds the first paint back. Both it and the check sit
+      inside `if len(screen.Events()) == 0` (`internal/pager.go:656`), which is
+      another reason the hold is a skipped redraw rather than a wait: a blocking
+      wait would sit inside a block we may not even enter.
+      A reload cannot un-set `HighlightingDone` under us during startup.
+      `reloadFromFile` (`internal/reader/watcher.go:54-55`) is the only place
+      that clears it, its only caller is the tailing loop, and `readStream`
+      starts that loop only after highlighting has finished once
+      (`internal/reader/consumer.go:50`) and it sleeps a second before its first
+      poll (`internal/reader/watcher.go:303-307`).
 
 - [ ] **8. Grace deadline for slow producers.**
       Short input that dribbles in over longer than the accidental window
       described under "Known residue" still flashes. Hold the first paint until
       reading finishes, a key or mouse event arrives, or a deadline of
-      ~50-100 ms expires, behind step 7's `GetLineCount() > height` gate so that
-      large inputs never wait.
+      ~50-100 ms expires. Reuse step 7's `shouldHoldFirstPaint()`, dropping its
+      `ReadingDone` requirement, so that large inputs still never wait: the
+      `fitsOnOneScreen()` gate releases the hold by itself as soon as the
+      growing input outgrows a screen, and the deadline then never matters.
       The numbers under "Known residue" are the input to picking the deadline.
       Deliberately parked: unlike every other step, this one requires somebody
       to choose a timeout, and it only buys the case where the producer is slow
@@ -231,6 +268,21 @@ not a reason to keep this file around.
   `--no-clear-on-exit-margin 0`, and quietly through `pkg/moor`, which sets
   `QuitIfOneScreen` but never `DeInitFalseMargin`.
 
+- **`FakeScreen.RequestTerminalBackgroundColor()` is dead code.**
+  `twin/fake-screen.go:104`. It is not part of the `Screen` interface, no
+  `UnixScreen` counterpart exists, and nothing calls it. Deletable as is.
+
+- **`FakeScreen.Events()` returns nil, with a `TODO` on it.**
+  `twin/fake-screen.go:112-115`. `<-nil` blocks forever, so no test using a
+  plain `FakeScreen` can run the pager main loop, which is a large hole given
+  how many tests use it. Step 7 sidesteps it with a local screen double
+  embedding `*twin.FakeScreen`, rather than fixing it, because handing
+  `FakeScreen` a real channel changes behavior under every existing user at
+  once: the goroutine at `internal/pager.go:641-643` does an unguarded
+  `screen.Events() <- eventMaybeDone{}`, which parks forever on today's nil
+  channel and would start filling a buffer instead. Worth doing properly if a
+  second test wants the main loop.
+
 ## Known residue after all of this
 
 Input that is short but dribbles in over longer than the grace period will
@@ -252,13 +304,25 @@ what pads the other column. Both numbers move with machine speed, and an earlier
 sweep on a busier machine put the answering column's edge closer to 40 ms. An
 explicit deadline would at least be a number somebody chose.
 
+Step 7's `fitsOnOneScreen()` gate looks at un-highlighted content, and
+highlighting can in one case make content *start* fitting: `--reformat` plus a
+single long JSON line that expands into a screenful. That input fails the gate,
+so it keeps its blink. `--reformat` is off by default
+(`cmd/moor/moor.go:397`).
+
 ## Test notes
 
 - `test.sh:104-105` runs `echo "  (success)" | ./moor --quit-if-one-screen` on
   a real TTY. That is the output-correctness contract to preserve.
 - `internal/pager_test.go` calls `Quit()` before `StartPaging`, so the main
   loop body never runs there. Steps 5, 7 and 8 do not disturb those tests,
-  which also means they will not catch regressions in them.
+  which also means they will not catch regressions in them. It couldn't run the
+  loop even without the `Quit()`: `twin.FakeScreen.Events()` returns nil
+  (`twin/fake-screen.go:112-115`) and `<-nil` blocks forever. A test that wants
+  the loop needs a screen double embedding `*twin.FakeScreen` with a real events
+  channel, which also gives it somewhere to count `Show()` calls. Embed
+  `*twin.FakeScreen`, pointer included, since its methods are all on pointer
+  receivers.
 - Many tests use `twin.NewFakeScreen`, so any new `Screen` interface method
   needs a no-op there.
 - `cmd/moor/moor_test.go` injects a fake `newScreen` into `pagerFromArgs`,
@@ -303,4 +367,9 @@ explicit deadline would at least be a number somebody chose.
 - Every pty test so far pages input chroma does not highlight, `.txt` files and
   unclassifiable piped text, which is the only reason they are not flaky. Any
   test of the startup path wanting the *highlighted* case needs a file argument
-  with a real extension, and will fail until step 7 lands.
+  with a real extension, or piped JSON, and will fail until step 7 lands. Such a
+  test cannot look for a multi-word phrase in the captured output, chroma puts
+  SGR sequences between the tokens; assert on a single identifier instead.
+  Pre-step-7 it only fails about half the time, so it is a regression net rather
+  than a reproducer, and the reproducer should be a deterministic pager level
+  test instead.

--- a/STARTUP-TUNING.md
+++ b/STARTUP-TUNING.md
@@ -172,7 +172,7 @@ One branch per step, each merged into master separately.
       colored line makes it obvious, which is what
       `TestReprintEndsWithStyleReset` pages.
 
-- [ ] **7. Close the highlighting race.**
+- [x] **7. Close the highlighting race.**
       `moor --quit-if-one-screen foo.go` still blinks, measured 7/15 on a 20
       line `.go` file. `HighlightingDone` is only preset at construction when
       there is no lexer (`internal/reader/constructors.go:56-58`), which is why
@@ -230,15 +230,36 @@ One branch per step, each merged into master separately.
       starts that loop only after highlighting has finished once
       (`internal/reader/consumer.go:50`) and it sleeps a second before its first
       poll (`internal/reader/watcher.go:303-307`).
+      Branch: `hold-first-paint-for-highlighting`. Measured with the pty harness
+      on a 20 line `.go` file, 15 runs each: 5/15 alternate screen entries
+      before, 0/15 after.
+      The predicate ended up named `canQuitIfOneScreen()` rather than
+      `shouldHoldFirstPaint()`, because the quit branch needs the same answer
+      and only the hold cares about `sawUserInput`. Holding is then a two line
+      `holdPaint := canQuit && !p.sawUserInput` at the call site. Step 8 wants
+      the hold without `canQuitIfOneScreen()`'s `ReadingDone` requirement, so it
+      will have to split the predicate rather than just reuse it.
+      Read `HighlightingDone` *before* counting the lines, never after.
+      Highlighting replaces the lines and only then sets the flag, so a flag
+      read first means the lines counted afterwards are the highlighted ones.
+      The other order can quit on a pre-highlighting count that highlighting
+      already invalidated, which with `--reformat` means a truncated file on
+      screen and exit code 0.
+      The reader hardening this step listed as optional turned out to be
+      required, and landed here rather than being deferred: with the hold in
+      place, a panic while highlighting means moor paints *nothing* until a
+      keypress, which is worse than the spinning spinner it used to mean.
 
 - [ ] **8. Grace deadline for slow producers.**
       Short input that dribbles in over longer than the accidental window
       described under "Known residue" still flashes. Hold the first paint until
       reading finishes, a key or mouse event arrives, or a deadline of
-      ~50-100 ms expires. Reuse step 7's `shouldHoldFirstPaint()`, dropping its
-      `ReadingDone` requirement, so that large inputs still never wait: the
-      `fitsOnOneScreen()` gate releases the hold by itself as soon as the
-      growing input outgrows a screen, and the deadline then never matters.
+      ~50-100 ms expires. Split step 7's `canQuitIfOneScreen()` so the hold gets
+      the same checks without its `ReadingDone` requirement, and large inputs
+      still never wait: the `fitsOnOneScreen()` part releases the hold by itself
+      as soon as the growing input outgrows a screen, and the deadline then never
+      matters. `sawUserInput` from step 7 is the "or a key or mouse event
+      arrives" half, already done.
       The numbers under "Known residue" are the input to picking the deadline.
       Deliberately parked: unlike every other step, this one requires somebody
       to choose a timeout, and it only buys the case where the producer is slow
@@ -376,9 +397,22 @@ so it keeps its blink. `--reformat` is off by default
 - Every pty test so far pages input chroma does not highlight, `.txt` files and
   unclassifiable piped text, which is the only reason they are not flaky. Any
   test of the startup path wanting the *highlighted* case needs a file argument
-  with a real extension, or piped JSON, and will fail until step 7 lands. Such a
-  test cannot look for a multi-word phrase in the captured output, chroma puts
-  SGR sequences between the tokens; assert on a single identifier instead.
-  Pre-step-7 it only fails about half the time, so it is a regression net rather
-  than a reproducer, and the reproducer should be a deterministic pager level
-  test instead.
+  with a real extension, or piped JSON. Such a test cannot look for a multi-word
+  phrase in the captured output, chroma puts SGR sequences between the tokens;
+  assert on a single identifier instead.
+- Step 7's tests are `internal/quit-if-one-screen_test.go` for the contract and
+  `TestQuitIfOneScreenNeverEntersAlternateScreenWhenHighlighted` in
+  `cmd/moor/alt-screen_test.go` for the end to end net. The pty one caught the
+  blink 4 times in 20 pre-step-7 subtest runs, so it is a net and not a
+  reproducer; the deterministic reproducer is the pager level one.
+- Size the input for a pty test of the highlighting race. Four lines of Go are
+  highlighted before the pager even starts, so such a test passes with or without
+  step 7. Twenty dense lines lose the race often enough to be worth having, and
+  still fit on the harness' 24 line screen. Time-sensitive either way: it is
+  measuring a margin of tens of microseconds.
+- The pager main loop cannot be run with a plain `twin.FakeScreen`, see the
+  `Events()` item under Deferred. `internal/quit-if-one-screen_test.go` has a
+  screen double that can, counts `Show()` calls, and uses sends on an unbuffered
+  event channel as handshakes with the main loop so that nothing has to sleep.
+  Ask it whether it painted *before* handing it an event it reacts to: the answer
+  is read once the pager is free to run on, so a later lap's paint lands in it.

--- a/cmd/moor/alt-screen_test.go
+++ b/cmd/moor/alt-screen_test.go
@@ -145,3 +145,51 @@ func TestQuitIfOneScreenNeverEntersAlternateScreen(t *testing.T) {
 		}
 	}
 }
+
+// Input that gets highlighted has to stay off the alternate screen too.
+//
+// Highlighting can turn contents that fit into contents that don't, so moor
+// cannot know whether it is quitting until highlighting is done. It has to wait
+// without painting: `MOOR=--quit-if-one-screen` plus a source file is a
+// mainstream invocation, and it flashed for as long as issue #425 was open.
+func TestQuitIfOneScreenNeverEntersAlternateScreenWhenHighlighted(t *testing.T) {
+	for _, answerBackgroundQuery := range []bool{true, false} {
+		for _, fromPipe := range []bool{false, true} {
+			name := fmt.Sprintf("answerBackgroundQuery=%t/fromPipe=%t", answerBackgroundQuery, fromPipe)
+			t.Run(name, func(t *testing.T) {
+				// One identifier, because highlighting would put escape
+				// sequences inside a phrase
+				marker := "hello_world"
+
+				// Enough lines that highlighting is still going when the pager
+				// starts, few enough that they fit on our 24 line screen
+				lineCount := 20
+
+				options := moorOptions{
+					answerBackgroundQuery: answerBackgroundQuery,
+					args:                  []string{"--quit-if-one-screen"},
+				}
+				if fromPipe {
+					lines := jsonLines(lineCount, marker)
+					options.stdin = &lines
+				} else {
+					options.args = append(options.args, createSourceFile(t, lineCount, marker))
+				}
+
+				session := startMoor(t, options)
+				session.wait(t)
+
+				captured := session.captured()
+
+				// Without this a moor that printed nothing at all would pass
+				assert.Assert(t, strings.Contains(captured, marker),
+					"Never printed the contents:\n%s", humanizeEscapes(captured))
+
+				assert.Assert(t, !strings.Contains(captured, altScreenEnter),
+					"Entered the alternate screen:\n%s", humanizeEscapes(captured))
+				assert.Assert(t, !strings.Contains(captured, altScreenLeave),
+					"Left the alternate screen:\n%s", humanizeEscapes(captured))
+			})
+		}
+	}
+}

--- a/cmd/moor/pty-harness_test.go
+++ b/cmd/moor/pty-harness_test.go
@@ -334,6 +334,44 @@ func textLines(lineCount int) string {
 // Creates a file with the requested number of lines, and returns its path. The
 // contents are the same as textLines() would give you, so that a test can page
 // the same text from a file and from a pipe.
+// Creates a Go source file with the requested number of lines, and returns its
+// path. Its extension is what gets it a chroma lexer, which is what makes moor
+// highlight it.
+//
+// The identifier goes into every line, for tests to look for in moor's output.
+// Keep it a single identifier: highlighting puts escape sequences between
+// tokens, so a phrase would not survive as one string.
+//
+// Ask for enough lines to be worth highlighting. A handful of lines are
+// highlighted before the pager even starts, which hides anything that depends on
+// highlighting still being underway.
+func createSourceFile(t *testing.T, lineCount int, identifier string) string {
+	t.Helper()
+
+	contents := strings.Builder{}
+	contents.WriteString("package main\n\nimport \"fmt\"\n\n")
+	// Two lines per iteration, after the four line header
+	for i := 1; i <= (lineCount-4)/2; i++ {
+		fmt.Fprintf(&contents, "// Comment number %d\nfunc %s%d() { fmt.Println(%d) }\n", i, identifier, i, i)
+	}
+
+	path := filepath.Join(t.TempDir(), "hello.go")
+	assert.NilError(t, os.WriteFile(path, []byte(contents.String()), 0o600))
+
+	return path
+}
+
+// Lines of JSON, which is highlighted based on its contents rather than on any
+// file name. Same identifier rules as createSourceFile().
+func jsonLines(lineCount int, identifier string) string {
+	contents := strings.Builder{}
+	for i := 1; i <= lineCount; i++ {
+		fmt.Fprintf(&contents, "{\"%s\": %d}\n", identifier, i)
+	}
+
+	return contents.String()
+}
+
 func createTextFile(t *testing.T, lineCount int) string {
 	t.Helper()
 

--- a/internal/filteringReader_test.go
+++ b/internal/filteringReader_test.go
@@ -67,8 +67,7 @@ func BenchmarkFilterHugeFile(b *testing.B) {
 	fr.rebuildCache() // warmup
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		fr.rebuildCache()
 	}
 }

--- a/internal/linewrapper_test.go
+++ b/internal/linewrapper_test.go
@@ -176,10 +176,7 @@ func BenchmarkWrapLine(b *testing.B) {
 
 	styledRunes := tokenize(line)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = wrapLine(73, styledRunes)
 	}
-
-	b.StopTimer()
 }

--- a/internal/pager.go
+++ b/internal/pager.go
@@ -56,8 +56,16 @@ type Pager struct {
 	// A view of the current reader, possibly filtered
 	filteringReader FilteringReader
 
-	screen         twin.Screen
-	quit           bool
+	screen twin.Screen
+	quit   bool
+
+	// Set once the user has pressed a key or used the mouse. Until then, and only
+	// while --quit-if-one-screen might still make us quit, we are allowed to
+	// paint nothing at all. Somebody who is interacting wants to see something.
+	//
+	// Written and read only by the main loop, like quit above, so no locking.
+	sawUserInput bool
+
 	scrollPosition scrollPosition
 
 	// How far right we have scrolled horizontally. The unit is visual screen
@@ -522,6 +530,17 @@ func (p *Pager) setTargetLine(targetLine *linemetadata.Index) {
 	r.SetPauseAfterLines(targetValue)
 }
 
+// True for events that mean the user did something, as opposed to us or the
+// reader making progress on our own.
+func isUserInput(event twin.Event) bool {
+	switch event.(type) {
+	case twin.EventKeyCode, twin.EventRune, twin.EventMouse:
+		return true
+	}
+
+	return false
+}
+
 // StartPaging brings up the pager on screen
 func (p *Pager) StartPaging(screen twin.Screen, chromaStyle *chroma.Style, chromaFormatter *chroma.Formatter) {
 	log.Info("Pager starting")
@@ -649,49 +668,60 @@ func (p *Pager) StartPaging(screen twin.Screen, chromaStyle *chroma.Style, chrom
 	// Main loop
 	spinner := ""
 	for !p.quit {
-		// Nothing more to process for now, so decide whether to quit, and redraw
-		// if we're staying. Deciding first is what keeps a quit-if-one-screen
-		// exit off the alternate screen: the redraw is what takes us there, and
-		// on the way out we never get that far.
 		if len(screen.Events()) == 0 {
+			// Nothing more to process for now, so decide whether to quit, and redraw
+			// if we're staying. Deciding first is what keeps a quit-if-one-screen
+			// exit off the alternate screen: the redraw is what takes us there, and
+			// on the way out we never get that far.
+
 			p.readerLock.Lock()
 			r := p.readers[p.currentReader]
 			p.readerLock.Unlock()
 
-			// Ref:
-			// https://github.com/gwsw/less/blob/ff8869aa0485f7188d942723c9fb50afb1892e62/command.c#L828-L831
-			//
-			// Note that we do the slow (atomic) checks only if the fast ones
-			// (no locking required) passed.
-			//
-			// Also, we only do this if we have exactly one reader, because
-			// that's what less does.
-			if len(p.readers) == 1 && p.QuitIfOneScreen && !p.isShowingHelp && r.ReadingDone.Load() && r.HighlightingDone.Load() {
-				if p.fitsOnOneScreen() {
-					// Leave the contents on the user's own screen, looking
-					// like cat printed them rather than like a pager did.
-					// DeInit false is what makes our caller call
-					// ReprintAfterExit(), and ReprintAfterExit() renders
-					// after we're done here, so it will pick up the line
-					// numbers setting.
-					//
-					// Ref:
-					// https://github.com/walles/moor/issues/113#issuecomment-1368294132
-					p.showLineNumbers = false
-					p.DeInit = false
-					p.quit = true
+			// Read this before looking at the contents, never after: highlighting
+			// replaces the lines and then sets the flag, so a flag we saw first
+			// means the lines we go on to count are the highlighted ones.
+			highlightingDone := r.HighlightingDone.Load()
 
-					log.Info("Exiting because of --quit-if-one-screen, everything fit on one screen and we're done")
+			canQuit := p.canQuitIfOneScreen(r)
 
-					// Exit the main loop
-					break
-				}
+			if canQuit && highlightingDone {
+				// Leave the contents on the user's own screen, looking like cat
+				// printed them.
+				//
+				// Ref:
+				// https://github.com/walles/moor/issues/113#issuecomment-1368294132
+				p.showLineNumbers = false // cat does no line numbers, so we shouldn't either
+				p.DeInit = false          // Makes ReprintAfterExit() be called on the way out
+				p.quit = true
+
+				log.Info("Exiting because of --quit-if-one-screen, everything fit on one screen and we're done")
+
+				// Exit the main loop
+				break
 			}
 
-			p.redraw(spinner)
+			// Highlighting can still grow the contents past one screen, so we
+			// don't know yet whether we are staying. Painting now and quitting
+			// right after is the blink of issue #425, so paint nothing and let
+			// the event read below wait for highlighting instead: it signals
+			// MaybeDone when it lands.
+			//
+			// Somebody who is interacting gets painted for regardless, which
+			// also means a reader that never finishes highlighting costs them a
+			// keypress rather than the whole session.
+			holdPaint := canQuit && !p.sawUserInput
+			if !holdPaint {
+				p.redraw(spinner)
+			}
 		}
 
 		event := <-screen.Events()
+
+		if isUserInput(event) {
+			p.sawUserInput = true
+		}
+
 		switch event := event.(type) {
 		case twin.EventKeyCode:
 			log.Tracef("Handling key event %d...", event.KeyCode())
@@ -797,6 +827,33 @@ func (p *Pager) fitsOnOneScreenWrapped() bool {
 	rendered := fakePager.renderLines()
 
 	return len(rendered.lines) < testScreenHeight
+}
+
+// True if --quit-if-one-screen is about to make us quit, or would be if
+// highlighting were done.
+//
+// Highlighting is deliberately not part of this: it is the one thing that can
+// still flip the answer, by reformatting the contents into more lines than fit,
+// and the caller needs to tell "no" apart from "not yet".
+//
+// Ref:
+// https://github.com/gwsw/less/blob/ff8869aa0485f7188d942723c9fb50afb1892e62/command.c#L828-L831
+func (p *Pager) canQuitIfOneScreen(r *reader.ReaderImpl) bool {
+	// Only with exactly one reader, because that's what less does
+	if len(p.readers) != 1 {
+		return false
+	}
+
+	if !p.QuitIfOneScreen || p.isShowingHelp {
+		return false
+	}
+
+	if !r.ReadingDone.Load() {
+		return false
+	}
+
+	// Counting the lines is the expensive part, so it goes last
+	return p.fitsOnOneScreen()
 }
 
 func (p *Pager) fitsOnOneScreen() bool {

--- a/internal/quit-if-one-screen_test.go
+++ b/internal/quit-if-one-screen_test.go
@@ -1,0 +1,162 @@
+package internal
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/walles/moor/v2/internal/reader"
+	"github.com/walles/moor/v2/twin"
+	"gotest.tools/v3/assert"
+)
+
+// How long to wait for the pager to get somewhere. Long enough that exceeding it
+// means the pager is stuck rather than slow.
+const pagerTimeout = time.Second
+
+// An event the pager has no handling for.
+//
+// Sending one on an unbuffered event channel completes only once the main loop
+// receives it, and the loop reads events after deciding whether to paint. So a
+// completed send means the decision has been made.
+type nudge struct{}
+
+// A screen that can run the pager main loop, and that counts paints.
+//
+// twin.FakeScreen.Events() returns nil, and receiving from a nil channel blocks
+// forever, so the main loop cannot be run with a plain FakeScreen.
+//
+// Show() is what takes over the user's terminal, alternate screen included, so
+// counting Show() calls is counting how much the user gets to see.
+type countingScreen struct {
+	*twin.FakeScreen
+	events chan twin.Event
+	shows  atomic.Int64
+}
+
+func newCountingScreen(width int, height int) *countingScreen {
+	return &countingScreen{
+		FakeScreen: twin.NewFakeScreen(width, height),
+
+		// Unbuffered, so that sending on it is a handshake with the main loop
+		events: make(chan twin.Event),
+	}
+}
+
+func (screen *countingScreen) Events() chan twin.Event {
+	return screen.events
+}
+
+func (screen *countingScreen) Show() {
+	screen.shows.Add(1)
+	screen.FakeScreen.Show()
+}
+
+// Start paging in the background, and stop paging again when the test ends.
+//
+// Returns a channel that is closed once paging is done.
+//
+// Stopping matters even for tests that expect the pager to quit on its own: a
+// pager left running keeps painting on its spinner ticks for as long as the test
+// binary lives, and it shares package level style state with the next test.
+func startPagingInBackground(t *testing.T, pager *Pager, screen *countingScreen) chan struct{} {
+	t.Helper()
+
+	pagingDone := make(chan struct{})
+	go func() {
+		pager.StartPaging(screen, nil, nil)
+		close(pagingDone)
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case screen.events <- twin.EventExit{}:
+		case <-pagingDone:
+		}
+
+		<-pagingDone
+	})
+
+	return pagingDone
+}
+
+// Wait for the pager to decide whether to paint, and report whether it painted.
+func paintedBeforeReadingEvents(t *testing.T, screen *countingScreen, pagingDone chan struct{}) bool {
+	t.Helper()
+
+	select {
+	case screen.events <- nudge{}:
+		return screen.shows.Load() > 0
+
+	case <-pagingDone:
+		t.Fatal("Pager quit instead of deciding whether to paint")
+
+	case <-time.After(pagerTimeout):
+		t.Fatal("Pager never got as far as reading events")
+	}
+
+	return false // Unreachable, t.Fatal() above ends the test
+}
+
+// With --quit-if-one-screen, contents that fit must never be painted, not even
+// while we are still waiting to find out whether they fit.
+//
+// Highlighting can change the answer, so until it is done we don't know. Ask the
+// user's terminal for nothing in the meantime: painting first and quitting right
+// after is the blink from https://github.com/walles/moor/issues/425.
+func TestQuitIfOneScreenPaintsNothingWhileHighlighting(t *testing.T) {
+	testReader := reader.NewFromTextForTesting("", "hello\nworld")
+
+	// NewFromTextForTesting() leaves this nil, and the pager needs it to hear
+	// about highlighting finishing. Assign before paging starts, the pager reads
+	// it from a goroutine of its own.
+	testReader.MaybeDone = make(chan bool, 2)
+
+	// Highlighting pending, like for a source file argument or piped JSON
+	testReader.HighlightingDone.Store(false)
+
+	screen := newCountingScreen(20, 10)
+
+	pager := NewPager(testReader)
+	pager.QuitIfOneScreen = true
+
+	pagingDone := startPagingInBackground(t, pager, screen)
+
+	painted := paintedBeforeReadingEvents(t, screen, pagingDone)
+	assert.Assert(t, !painted,
+		"Nothing should be painted while we don't know whether the contents fit")
+
+	// Now we know, and two lines do fit on ten, so the pager should quit
+	testReader.HighlightingDone.Store(true)
+	testReader.MaybeDone <- true
+
+	select {
+	case <-pagingDone:
+	case <-time.After(pagerTimeout):
+		t.Fatal("Pager should have quit, two lines fit on ten")
+	}
+}
+
+// Contents that do not fit must be painted right away, without waiting for
+// highlighting.
+//
+// Highlighting only ever gets us more lines to show, so contents that are
+// already too tall are staying too tall. We know we are staying, and waiting
+// would be latency in front of the first paint for nothing.
+func TestQuitIfOneScreenPaintsContentsThatDoNotFit(t *testing.T) {
+	testReader := reader.NewFromTextForTesting("", strings.Repeat("hello\n", 20))
+	testReader.MaybeDone = make(chan bool, 2)
+	testReader.HighlightingDone.Store(false)
+
+	screen := newCountingScreen(20, 10)
+
+	pager := NewPager(testReader)
+	pager.QuitIfOneScreen = true
+
+	pagingDone := startPagingInBackground(t, pager, screen)
+
+	painted := paintedBeforeReadingEvents(t, screen, pagingDone)
+	assert.Assert(t, painted,
+		"Contents that don't fit should be painted without waiting for highlighting")
+}

--- a/internal/quit-if-one-screen_test.go
+++ b/internal/quit-if-one-screen_test.go
@@ -81,22 +81,38 @@ func startPagingInBackground(t *testing.T, pager *Pager, screen *countingScreen)
 	return pagingDone
 }
 
-// Wait for the pager to decide whether to paint, and report whether it painted.
-func paintedBeforeReadingEvents(t *testing.T, screen *countingScreen, pagingDone chan struct{}) bool {
+// Hand an event to the pager, and wait for the pager to take it.
+//
+// Fails the test rather than hanging if the pager is not taking events.
+func handEvent(t *testing.T, screen *countingScreen, pagingDone chan struct{}, event twin.Event) {
 	t.Helper()
 
 	select {
-	case screen.events <- nudge{}:
-		return screen.shows.Load() > 0
+	case screen.events <- event:
 
 	case <-pagingDone:
-		t.Fatal("Pager quit instead of deciding whether to paint")
+		t.Fatal("Pager quit instead of taking our event")
 
 	case <-time.After(pagerTimeout):
 		t.Fatal("Pager never got as far as reading events")
 	}
+}
 
-	return false // Unreachable, t.Fatal() above ends the test
+// Report whether the pager has painted anything, once it has decided whether to.
+//
+// The pager takes events only after deciding, so handing it an event it ignores
+// and waiting for that to be taken puts the decision behind us.
+//
+// Only ever asks about paints up to that decision. A caller that hands over
+// something the pager reacts to must ask before handing it over, not after: this
+// answer is read after the pager is free to run on, so a later lap's paint can
+// still land in it.
+func hasPainted(t *testing.T, screen *countingScreen, pagingDone chan struct{}) bool {
+	t.Helper()
+
+	handEvent(t, screen, pagingDone, nudge{})
+
+	return screen.shows.Load() > 0
 }
 
 // With --quit-if-one-screen, contents that fit must never be painted, not even
@@ -123,7 +139,7 @@ func TestQuitIfOneScreenPaintsNothingWhileHighlighting(t *testing.T) {
 
 	pagingDone := startPagingInBackground(t, pager, screen)
 
-	painted := paintedBeforeReadingEvents(t, screen, pagingDone)
+	painted := hasPainted(t, screen, pagingDone)
 	assert.Assert(t, !painted,
 		"Nothing should be painted while we don't know whether the contents fit")
 
@@ -156,7 +172,37 @@ func TestQuitIfOneScreenPaintsContentsThatDoNotFit(t *testing.T) {
 
 	pagingDone := startPagingInBackground(t, pager, screen)
 
-	painted := paintedBeforeReadingEvents(t, screen, pagingDone)
+	painted := hasPainted(t, screen, pagingDone)
 	assert.Assert(t, painted,
 		"Contents that don't fit should be painted without waiting for highlighting")
+}
+
+// Waiting for highlighting must never cost the user their session.
+//
+// Highlighting is not guaranteed to finish: a panic while highlighting is only
+// logged, and leaves it pending forever. So the wait lasts only until the user
+// does something, and then they get their contents.
+func TestQuitIfOneScreenPaintsForAUserWhoAsks(t *testing.T) {
+	testReader := reader.NewFromTextForTesting("", "hello\nworld")
+	testReader.MaybeDone = make(chan bool, 2)
+
+	// Highlighting that never finishes, like after a panic while highlighting
+	testReader.HighlightingDone.Store(false)
+
+	screen := newCountingScreen(20, 10)
+
+	pager := NewPager(testReader)
+	pager.QuitIfOneScreen = true
+
+	pagingDone := startPagingInBackground(t, pager, screen)
+
+	painted := hasPainted(t, screen, pagingDone)
+	assert.Assert(t, !painted, "Nothing should be painted before the user asks")
+
+	// A mouse event with no buttons set: the pager has nothing to do about it
+	// beyond noticing that somebody is there.
+	handEvent(t, screen, pagingDone, twin.EventMouse{})
+
+	painted = hasPainted(t, screen, pagingDone)
+	assert.Assert(t, painted, "A user who asks should get the contents, highlighted or not")
 }

--- a/internal/reader/constructors.go
+++ b/internal/reader/constructors.go
@@ -156,7 +156,22 @@ func newReaderFromStream(reader io.Reader, originalFileName *string, formatter c
 
 	go func() {
 		defer func() {
-			PanicHandler("newReaderFromStream()/readStream()", recover(), debug.Stack())
+			panicResult := recover()
+			PanicHandler("newReaderFromStream()/readStream()", panicResult, debug.Stack())
+			if panicResult == nil {
+				return
+			}
+
+			// Whatever we got before the panic is all there is ever going to be,
+			// so say we're done. Otherwise everybody waiting for us waits
+			// forever: the pager holds its first paint until highlighting is
+			// done, and it spins its spinner until reading is.
+			returnMe.ReadingDone.Store(true)
+			returnMe.HighlightingDone.Store(true)
+			select {
+			case returnMe.MaybeDone <- true:
+			default:
+			}
 		}()
 
 		returnMe.readStream(reader, formatter, options)

--- a/internal/reader/constructors_test.go
+++ b/internal/reader/constructors_test.go
@@ -6,11 +6,14 @@ import (
 	"math"
 	"os"
 	"path"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/klauspost/compress/zstd"
 	"gotest.tools/v3/assert"
 )
@@ -26,6 +29,40 @@ func TestReadTextDone(t *testing.T) {
 	testMe := NewFromTextForTesting("", "Johan")
 
 	assert.NilError(t, testMe.Wait())
+}
+
+type panickingFormatter struct{}
+
+func (formatter panickingFormatter) Format(io.Writer, *chroma.Style, chroma.Iterator) error {
+	panic("Highlighting blew up")
+}
+
+// A reader that panics on the way is still done afterwards, so that whoever
+// waits for it can stop waiting.
+//
+// Panics in a reader are logged rather than propagated, so without this the
+// pager would hold back its first paint forever waiting for highlighting, and
+// spin its spinner forever waiting for reading.
+func TestReaderIsDoneAfterHighlightingPanics(t *testing.T) {
+	testMe, err := NewFromStream("", strings.NewReader(`{"one": 1}`),
+		panickingFormatter{}, ReaderOptions{Lexer: lexers.Get("json")})
+	assert.NilError(t, err)
+
+	// Highlighting waits for this, and panics once it arrives
+	testMe.SetStyleForHighlighting(*styles.Get("native"))
+
+	giveUp := time.After(time.Second)
+	for !testMe.HighlightingDone.Load() {
+		select {
+		case <-testMe.MaybeDone:
+			// Progress, look again
+
+		case <-giveUp:
+			t.Fatal("Highlighting never reported done after panicking")
+		}
+	}
+
+	assert.Assert(t, testMe.ReadingDone.Load(), "Reading should be done as well")
 }
 
 // NewFromStream takes ownership of the stream, so once it has consumed the


### PR DESCRIPTION
Step 7 of the startup tuning notes for #425.

## The problem

`--quit-if-one-screen` decides whether the contents fit and quits if they do. That decision required `HighlightingDone`, so while highlighting was still pending the decision was skipped, a frame was painted, and moor quit right after. Painting is what enters the alternate screen, so the terminal flashed.

Highlighting is pending for anything chroma has a lexer for, which is why `git branch | moor` came out clean after step 5 while `moor foo.go` and piped JSON still blinked. `MOOR=--quit-if-one-screen` plus a source file is a mainstream invocation.

## The fix

`canQuitIfOneScreen()` answers everything except highlighting. When it says yes and highlighting is done, we quit as before. When it says yes and highlighting is still pending, we now paint nothing and let the event read wait: highlighting signals `MaybeDone` when it lands, which the pager already turns into an event.

Two things keep that from turning into a hang:

- The hold is off once the user has pressed a key or used the mouse, so a reader that never finishes highlighting costs a keypress rather than the session.
- A panic in the reader goroutine is logged and swallowed, which used to leave highlighting pending forever. The reader now reports itself done when it panics. That also fixes a spinner that used to spin forever after a reader panic.

`HighlightingDone` is read *before* the line count, not after. Highlighting replaces the lines and only then sets the flag, so reading the flag first is what guarantees the lines counted afterwards are the highlighted ones. The other order can quit on a count that highlighting has already invalidated, which under `--reformat` would print a truncated file and exit 0.

## Measurements

pty harness, 20 line `.go` file, 15 runs each, alternate screen entries: **5/15 before, 0/15 after**.

## Testing

- `internal/quit-if-one-screen_test.go` is the deterministic reproducer, plus the two other halves of the contract: content that does not fit is still painted promptly, and a user who asks gets painted for. It needs a screen double, because `twin.FakeScreen.Events()` returns nil and the main loop cannot run on that. Sends on an unbuffered event channel act as handshakes with the main loop, so nothing sleeps.
- `TestQuitIfOneScreenNeverEntersAlternateScreenWhenHighlighted` covers a `.go` file argument and piped JSON end to end. It is a net rather than a reproducer: it caught the blink 4 times in 20 pre-fix subtest runs. Input size matters — four lines of Go are highlighted before the pager even starts, and a test that small passes either way.
- Each test was checked against a mutation of the code it covers, so none of them pass for the wrong reason.
- `./test.sh` passes, `golangci-lint` reports 0 issues, no race reports.

## Also in here

Two unrelated drive-bys, each in its own commit: two `b.N` benchmark loops modernized to `b.Loop()`, and a note in the tuning file that `go test -count=5 ./internal/` fails `TestSearchHighlight` on master because the package level style variables are never reset.

Step 8, the grace deadline for slow producers, is still open and now has to split `canQuitIfOneScreen()` rather than reuse it as it stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code), model Opus 5