### PR TITLE
Bump Go to 1.27

### DIFF
--- a/cmd/moor/alt-screen_test.go
+++ b/cmd/moor/alt-screen_test.go
@@ -19,8 +19,7 @@ func TestLongInputUsesAlternateScreen(t *testing.T) {
 		t.Run(fmt.Sprintf("fromPipe=%t", fromPipe), func(t *testing.T) {
 			options := moorOptions{answerBackgroundQuery: true}
 			if fromPipe {
-				hundredLines := textLines(100)
-				options.stdin = &hundredLines
+				options.stdin = new(textLines(100))
 			} else {
 				options.args = []string{createTextFile(t, 100)}
 			}
@@ -119,8 +118,7 @@ func TestQuitIfOneScreenNeverEntersAlternateScreen(t *testing.T) {
 					args:                  []string{"--quit-if-one-screen"},
 				}
 				if fromPipe {
-					twoLines := "hello world 1\nhello world 2\n"
-					options.stdin = &twoLines
+					options.stdin = new("hello world 1\nhello world 2\n")
 				} else {
 					options.args = append(options.args, createTextFile(t, 2))
 				}
@@ -170,8 +168,7 @@ func TestQuitIfOneScreenNeverEntersAlternateScreenWhenHighlighted(t *testing.T) 
 					args:                  []string{"--quit-if-one-screen"},
 				}
 				if fromPipe {
-					lines := jsonLines(lineCount, marker)
-					options.stdin = &lines
+					options.stdin = new(jsonLines(lineCount, marker))
 				} else {
 					options.args = append(options.args, createSourceFile(t, lineCount, marker))
 				}

--- a/cmd/moor/moor.go
+++ b/cmd/moor/moor.go
@@ -628,8 +628,7 @@ func pagerFromArgs(
 
 	pager.TargetLine = targetLine
 	if *follow && pager.TargetLine == nil {
-		reallyHigh := linemetadata.IndexMax()
-		pager.TargetLine = &reallyHigh
+		pager.TargetLine = new(linemetadata.IndexMax())
 	}
 
 	return pager, screen, style, &formatter, logsRequested, nil

--- a/cmd/moor/plusparser.go
+++ b/cmd/moor/plusparser.go
@@ -59,8 +59,7 @@ func parseLineNumber(withoutPlus string) *linemetadata.Index {
 		lineNumber = 1
 	}
 
-	targetIndex := linemetadata.IndexFromOneBased(int(lineNumber))
-	return &targetIndex
+	return new(linemetadata.IndexFromOneBased(int(lineNumber)))
 }
 
 func parseSearchPattern(withoutPlus string) *string {
@@ -68,6 +67,5 @@ func parseSearchPattern(withoutPlus string) *string {
 		return nil
 	}
 
-	pattern := withoutPlus[1:]
-	return &pattern
+	return new(withoutPlus[1:])
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/walles/moor/v2
 
-go 1.25.0
+go 1.27.0
 
 require (
 	github.com/adrg/xdg v0.5.3

--- a/internal/editor.go
+++ b/internal/editor.go
@@ -118,8 +118,7 @@ func middleVisibleLine(p *Pager) *linemetadata.Index {
 		return nil
 	}
 
-	middle := lines[len(lines)/2].inputLineIndex
-	return &middle
+	return new(lines[len(lines)/2].inputLineIndex)
 }
 
 // check if the editor can accept "+LINENUMBER" argument

--- a/internal/file-switching_test.go
+++ b/internal/file-switching_test.go
@@ -25,11 +25,9 @@ func TestIssue426SwitchingToSmallerFileClearsStaleScrollPosition(t *testing.T) {
 
 	// This matches the stale post-switch state from issue #426: the reader has
 	// moved to a shorter file, but the scroll position still points below it.
-	staleIndex := linemetadata.IndexFromZeroBased(70)
-	staleIndexPtr := &staleIndex
 	pager.scrollPosition = scrollPosition{
 		internalDontTouch: scrollPositionInternal{
-			lineIndex: staleIndexPtr,
+			lineIndex: new(linemetadata.IndexFromZeroBased(70)),
 			delta:     0,
 			name:      "Issue 426 stale file switch",
 		},

--- a/internal/filteringReader_test.go
+++ b/internal/filteringReader_test.go
@@ -59,10 +59,9 @@ func BenchmarkFilterHugeFile(b *testing.B) {
 	input := reader.NewFromTextForTesting("BenchmarkFilterHugeFile()", text)
 	assert.NilError(b, input.Wait())
 
-	filterTerm := search.For("Periodic")
 	fr := FilteringReader{
 		BackingReader: input,
-		Filter:        &filterTerm,
+		Filter:        new(search.For("Periodic")),
 	}
 	fr.rebuildCache() // warmup
 

--- a/internal/pager.go
+++ b/internal/pager.go
@@ -263,8 +263,7 @@ func NewPager(readers ...*reader.ReaderImpl) *Pager {
 		Filter:        &pager.filter,
 	}
 
-	searchHistory := BootSearchHistory("")
-	pager.searchHistory = &searchHistory
+	pager.searchHistory = new(BootSearchHistory(""))
 
 	return &pager
 }
@@ -471,8 +470,7 @@ func (p *Pager) handleScrolledUp() {
 func (p *Pager) handleScrolledDown() {
 	if p.isScrolledToEnd() {
 		// Follow output
-		reallyHigh := linemetadata.IndexMax()
-		p.setTargetLine(&reallyHigh)
+		p.setTargetLine(new(linemetadata.IndexMax()))
 	} else {
 		p.setTargetLine(nil)
 	}

--- a/internal/pager_test.go
+++ b/internal/pager_test.go
@@ -772,8 +772,7 @@ func TestHandleMoreLinesAvailableWithEmptyFile(t *testing.T) {
 	pager := NewPager(emptyReader)
 
 	// Simulate --follow mode by setting target to max
-	targetLine := linemetadata.IndexMax()
-	pager.TargetLine = &targetLine
+	pager.TargetLine = new(linemetadata.IndexMax())
 
 	// This should not crash when lineCount is 0
 	pager.handleMoreLinesAvailable()

--- a/internal/pagermode-viewing.go
+++ b/internal/pagermode-viewing.go
@@ -173,16 +173,14 @@ func (m PagerModeViewing) onRune(char rune) {
 		p.search.Clear()
 
 		// Searchers want to scan the whole file, start reading as much as we can
-		reallyHigh := linemetadata.IndexMax()
-		p.setTargetLine(&reallyHigh)
+		p.setTargetLine(new(linemetadata.IndexMax()))
 
 	case '?':
 		p.mode = NewPagerModeSearch(p, SearchDirectionBackward, p.scrollPosition)
 		p.search.Clear()
 
 		// Searchers want to scan the whole file, start reading as much as we can
-		reallyHigh := linemetadata.IndexMax()
-		p.setTargetLine(&reallyHigh)
+		p.setTargetLine(new(linemetadata.IndexMax()))
 
 	case '&':
 		if !p.isShowingHelp {

--- a/internal/reader/constructors.go
+++ b/internal/reader/constructors.go
@@ -48,8 +48,7 @@ func NewFromFilename(filename string, formatter chroma.Formatter, options Reader
 	returnMe.lastStat = initialStat
 
 	// Ensure the display name matches the highlighting name (e.g. without .gz)
-	basename := filepath.Base(highlightingFilename)
-	returnMe.DisplayName = &basename
+	returnMe.DisplayName = new(filepath.Base(highlightingFilename))
 
 	returnMe.IsCompressed = (filename != highlightingFilename)
 
@@ -128,8 +127,7 @@ func newReaderFromStream(reader io.Reader, originalFileName *string, formatter c
 	}
 	var displayFileName *string
 	if originalFileName != nil {
-		basename := filepath.Base(*originalFileName)
-		displayFileName = &basename
+		displayFileName = new(filepath.Base(*originalFileName))
 	}
 	streamCloser, _ := reader.(io.Closer)
 	returnMe := ReaderImpl{
@@ -194,8 +192,7 @@ func NewFromTextForTesting(name string, text string) *ReaderImpl {
 	lines := []*Line{}
 	if len(noExternalNewlines) > 0 {
 		for lineString := range strings.SplitSeq(noExternalNewlines, "\n") {
-			line := Line{raw: []byte(lineString)}
-			lines = append(lines, &line)
+			lines = append(lines, new(Line{raw: []byte(lineString)}))
 		}
 	}
 	readingDone := atomic.Bool{}

--- a/internal/reader/highlight.go
+++ b/internal/reader/highlight.go
@@ -66,9 +66,8 @@ func Highlight(text string, style chroma.Style, formatter chroma.Formatter, lexe
 	// (always?) puts one of those by itself on the last line, making us believe
 	// there is one line too many.
 	sgrReset := "\x1b[0m"
-	trimmed := strings.TrimSuffix(highlighted, sgrReset)
 
-	return &trimmed, nil
+	return new(strings.TrimSuffix(highlighted, sgrReset)), nil
 }
 
 // Reports whether every visible character of some highlighted text looks the

--- a/internal/reader/reader.go
+++ b/internal/reader/reader.go
@@ -556,8 +556,7 @@ func (reader *ReaderImpl) PumpToStdout() {
 func (reader *ReaderImpl) setText(text string) {
 	lines := []*Line{}
 	for lineString := range strings.SplitSeq(text, "\n") {
-		line := Line{raw: []byte(lineString)}
-		lines = append(lines, &line)
+		lines = append(lines, new(Line{raw: []byte(lineString)}))
 	}
 
 	if len(lines) > 0 && strings.HasSuffix(text, "\n") {

--- a/internal/screenLines.go
+++ b/internal/screenLines.go
@@ -273,8 +273,7 @@ func (p *Pager) renderLine(line reader.NumberedLine, numberPrefixLength int, hig
 
 	rendered := make([]renderedLine, 0)
 	for wrapIndex, subLine := range wrapped {
-		lineNumber := line.Number
-		visibleLineNumber := &lineNumber
+		visibleLineNumber := new(line.Number)
 		if wrapIndex > 0 {
 			visibleLineNumber = nil
 		}
@@ -323,12 +322,9 @@ func (p *Pager) decorateLine(lineNumberToShow *linemetadata.Number, numberPrefix
 	canScrollRight := false
 	for i, char := range contents {
 		if firstVisibleRuneIndex == nil && screenColumn >= p.leftColumnZeroBased {
-			// Found the first fully visible rune. We need to point to a copy of
-			// our loop variable, not the loop variable itself. Just pointing to
-			// i, will make firstVisibleRuneIndex point to a new value for every
-			// iteration of the loop.
-			copyOfI := i
-			firstVisibleRuneIndex = &copyOfI
+			// Found the first fully visible rune. new(i) gives us a fresh
+			// address each iteration, rather than aliasing the loop variable.
+			firstVisibleRuneIndex = new(i)
 			if i > 0 && screenColumn > p.leftColumnZeroBased && contents[i-1].Width() > 1 {
 				// We had to cut a rune in half at the start
 				cutOffRuneToTheLeft = true

--- a/internal/scrollPosition.go
+++ b/internal/scrollPosition.go
@@ -218,8 +218,7 @@ func (si *scrollPositionInternal) handlePositiveDelta(pager *Pager) {
 			return
 		}
 
-		nextLineIndex := si.lineIndex.NonWrappingAdd(1)
-		si.lineIndex = &nextLineIndex
+		si.lineIndex = new(si.lineIndex.NonWrappingAdd(1))
 		si.delta -= linemetadata.ScreenLines(len(subLines))
 	}
 }
@@ -376,8 +375,7 @@ func (p *Pager) scrollToEnd() {
 		//
 		// Otherwise, if we're already aiming for some place, don't overwrite
 		// that.
-		maxLineIndex := linemetadata.IndexMax()
-		p.setTargetLine(&maxLineIndex)
+		p.setTargetLine(new(linemetadata.IndexMax()))
 	}
 }
 
@@ -425,8 +423,7 @@ func (p *Pager) getLastVisibleLineIndex() *linemetadata.Index {
 		return nil
 	}
 
-	lastRenderedLine := rendered.lines[len(rendered.lines)-1]
-	return &lastRenderedLine.inputLineIndex
+	return new(rendered.lines[len(rendered.lines)-1].inputLineIndex)
 }
 
 // getMaxNumberPrefixLength returns the maximum line number prefix length

--- a/internal/scrollPosition_test.go
+++ b/internal/scrollPosition_test.go
@@ -15,23 +15,26 @@ const screenHeight = 60
 
 // Repro for: https://github.com/walles/moor/issues/166
 func testCanonicalize1000(t *testing.T, withStatusBar bool, currentStartLine linemetadata.Index, lastVisibleLine linemetadata.Index) {
-	pager := Pager{}
-	pager.screen = twin.NewFakeScreen(100, screenHeight)
-	pager.readers = []*reader.ReaderImpl{reader.NewFromTextForTesting("test", strings.Repeat("a\n", 2000))}
+	pager := Pager{
+		screen: twin.NewFakeScreen(100, screenHeight),
+		readers: []*reader.ReaderImpl{
+			reader.NewFromTextForTesting("test", strings.Repeat("a\n", 2000)),
+		},
+		ShowLineNumbers: true,
+		showLineNumbers: true,
+		ShowStatusBar:   withStatusBar,
+		scrollPosition: scrollPosition{
+			internalDontTouch: scrollPositionInternal{
+				lineIndex:      &currentStartLine,
+				delta:          0,
+				name:           "findFirstHit",
+				canonicalizing: false,
+			},
+		},
+	}
 	pager.filteringReader = FilteringReader{
 		BackingReader: pager.readers[pager.currentReader],
 		Filter:        &pager.filter,
-	}
-	pager.ShowLineNumbers = true
-	pager.showLineNumbers = true
-	pager.ShowStatusBar = withStatusBar
-	pager.scrollPosition = scrollPosition{
-		internalDontTouch: scrollPositionInternal{
-			lineIndex:      &currentStartLine,
-			delta:          0,
-			name:           "findFirstHit",
-			canonicalizing: false,
-		},
 	}
 
 	lastVisiblePosition := scrollPosition{
@@ -71,22 +74,22 @@ func TestCanonicalize1000WithoutStatusBar(t *testing.T) {
 // lines of input.
 func tryScrollAmount(t *testing.T, scrollFrom linemetadata.Index, scrollDistance linemetadata.ScreenLines) {
 	// Create 1492 lines of single-char content
-	pager := Pager{}
-	pager.screen = twin.NewFakeScreen(80, screenHeight)
-	pager.readers = []*reader.ReaderImpl{reader.NewFromTextForTesting("test", strings.Repeat("x\n", 1492))}
+	pager := Pager{
+		screen:          twin.NewFakeScreen(80, screenHeight),
+		readers:         []*reader.ReaderImpl{reader.NewFromTextForTesting("test", strings.Repeat("x\n", 1492))},
+		ShowLineNumbers: true,
+		showLineNumbers: true,
+		scrollPosition: scrollPosition{
+			internalDontTouch: scrollPositionInternal{
+				name:      "tryScrollAmount",
+				lineIndex: &scrollFrom,
+				delta:     scrollDistance,
+			},
+		},
+	}
 	pager.filteringReader = FilteringReader{
 		BackingReader: pager.readers[pager.currentReader],
 		Filter:        &pager.filter,
-	}
-	pager.ShowLineNumbers = true
-	pager.showLineNumbers = true
-
-	pager.scrollPosition = scrollPosition{
-		internalDontTouch: scrollPositionInternal{
-			name:      "tryScrollAmount",
-			lineIndex: &scrollFrom,
-			delta:     scrollDistance,
-		},
 	}
 
 	// Trigger rendering (and canonicalization). If the prefix is miscomputed

--- a/internal/scrollPosition_test.go
+++ b/internal/scrollPosition_test.go
@@ -174,12 +174,9 @@ func TestIssue399(t *testing.T) {
 	pager := NewPager(r)
 
 	spci := scrollPositionInternal{
-		lineIndex: func(i int) *linemetadata.Index {
-			idx := linemetadata.IndexFromZeroBased(i)
-			return &idx
-		}(900),
-		delta: 569,
-		name:  "scrollToSearchHits",
+		lineIndex: new(linemetadata.IndexFromZeroBased(900)),
+		delta:     569,
+		name:      "scrollToSearchHits",
 	}
 
 	pager.scrollPosition = scrollPosition{
@@ -220,12 +217,9 @@ func TestIssue415Panic(t *testing.T) {
 	pager := NewPager(r)
 	pager.filteringReader.BackingReader = &shrinkingReader{Reader: r}
 	spci := scrollPositionInternal{
-		lineIndex: func(i int) *linemetadata.Index {
-			idx := linemetadata.IndexFromZeroBased(i)
-			return &idx
-		}(10), // start out of bounds (past what the reader claims it has)
-		delta: 0,
-		name:  "test415",
+		lineIndex: new(linemetadata.IndexFromZeroBased(10)), // start out of bounds (past what the reader claims it has)
+		delta:     0,
+		name:      "test415",
 	}
 
 	pager.scrollPosition = scrollPosition{

--- a/internal/styling.go
+++ b/internal/styling.go
@@ -264,8 +264,7 @@ func configureHighlighting(terminalBackground *twin.Color, configureSearchHitLin
 	if plainBg != twin.ColorDefault && hitBg != twin.ColorDefault {
 		// We have two real colors. Mix them! I got to "0.2" by testing some
 		// numbers. 0.2 is visible but not too strong.
-		mixed := plainBg.Mix(hitBg, 0.2)
-		theme.searchHitLineBackground = &mixed
+		theme.searchHitLineBackground = new(plainBg.Mix(hitBg, 0.2))
 
 		log.Trace("Search hit line background set to mixed color: ", *theme.searchHitLineBackground)
 	} else {

--- a/internal/textstyles/ansiTokenizer.go
+++ b/internal/textstyles/ansiTokenizer.go
@@ -824,8 +824,7 @@ func consumeCompositeColor(numbers []uint, index int) (int, *twin.Color, error) 
 
 		colorNumber := numbers[index]
 
-		colorValue := twin.NewColor256(uint8(colorNumber))
-		return index + 1, &colorValue, nil
+		return index + 1, new(twin.NewColor256(uint8(colorNumber))), nil
 	}
 
 	if numbers[index] == 2 {
@@ -845,9 +844,7 @@ func consumeCompositeColor(numbers []uint, index int) (int, *twin.Color, error) 
 		gValue := uint8(numbers[gIndex])
 		bValue := uint8(numbers[bIndex])
 
-		colorValue := twin.NewColor24Bit(rValue, gValue, bValue)
-
-		return bIndex + 1, &colorValue, nil
+		return bIndex + 1, new(twin.NewColor24Bit(rValue, gValue, bValue)), nil
 	}
 
 	err := fmt.Errorf(

--- a/internal/textstyles/ansiTokenizer_test.go
+++ b/internal/textstyles/ansiTokenizer_test.go
@@ -71,8 +71,7 @@ func TestTokenize(t *testing.T) {
 				if lineIndex == nil {
 					lineIndex = &linemetadata.Index{}
 				} else {
-					next := lineIndex.NonWrappingAdd(1)
-					lineIndex = &next
+					lineIndex = new(lineIndex.NonWrappingAdd(1))
 				}
 
 				var loglines strings.Builder

--- a/internal/textstyles/cellWithMetadata.go
+++ b/internal/textstyles/cellWithMetadata.go
@@ -1,6 +1,7 @@
 package textstyles
 
 import (
+	"slices"
 	"unicode"
 
 	"github.com/walles/moor/v2/twin"
@@ -86,8 +87,7 @@ func (runes CellWithMetadataSlice) WithoutSpaceLeft() CellWithMetadataSlice {
 
 // Returns a copy of the slice with trailing whitespace removed
 func (runes CellWithMetadataSlice) WithoutSpaceRight() CellWithMetadataSlice {
-	for i := len(runes) - 1; i >= 0; i-- {
-		cell := runes[i]
+	for i, cell := range slices.Backward(runes) {
 		if !unicode.IsSpace(cell.Rune) {
 			return runes[0 : i+1]
 		}

--- a/internal/textstyles/styledStringSplitter.go
+++ b/internal/textstyles/styledStringSplitter.go
@@ -477,8 +477,7 @@ func (s *styledStringSplitter) handleURL() error {
 
 			// End of URL
 			urlEndIndexExclusive := s.nextByteIndex - 2
-			url := s.input[urlStartIndex:urlEndIndexExclusive]
-			s.startNewPart(s.inProgressStyle.WithHyperlink(&url))
+			s.startNewPart(s.inProgressStyle.WithHyperlink(new(s.input[urlStartIndex:urlEndIndexExclusive])))
 			return nil
 		}
 
@@ -492,8 +491,7 @@ func (s *styledStringSplitter) handleURL() error {
 		if char == '\x07' {
 			// End of URL
 			urlEndIndexExclusive := s.nextByteIndex - 1
-			url := s.input[urlStartIndex:urlEndIndexExclusive]
-			s.startNewPart(s.inProgressStyle.WithHyperlink(&url))
+			s.startNewPart(s.inProgressStyle.WithHyperlink(new(s.input[urlStartIndex:urlEndIndexExclusive])))
 			return nil
 		}
 

--- a/internal/util/format.go
+++ b/internal/util/format.go
@@ -1,6 +1,9 @@
 package util
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 // Formats a positive number into a string with _ between each three-group of
 // digits, for numbers >= 10_000.
@@ -16,8 +19,7 @@ func FormatInt(i int) string {
 
 	chars := []rune(fmt.Sprint(i))
 	addCount := 0
-	for i := len(chars) - 1; i >= 0; i-- {
-		char := chars[i]
+	for _, char := range slices.Backward(chars) {
 		if len(result) > 0 && addCount%3 == 0 {
 			result = "_" + result
 		}

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -180,20 +180,20 @@ func NewScreenWithMouseModeAndColorCount(mouseMode MouseMode, terminalColorCount
 	screen := UnixScreen{
 		terminalColorCount: terminalColorCount,
 		mouseMode:          mouseMode,
-	}
 
-	// The number "80" here is from manual testing on my MacBook:
-	//
-	// First, start "./moor.sh sample-files/large-git-log-patch.txt".
-	//
-	// Then do a two finger flick initiating a momentum based scroll-up.
-	//
-	// Now, if you get "Events buffer full" warnings, the buffer is too small.
-	//
-	// By this definition, 40 was too small, and 80 was OK.
-	//
-	// Bumped to 160 because of: https://github.com/walles/moor/issues/164
-	screen.events = make(chan Event, 160)
+		// The number "80" here is from manual testing on my MacBook:
+		//
+		// First, start "./moor.sh sample-files/large-git-log-patch.txt".
+		//
+		// Then do a two finger flick initiating a momentum based scroll-up.
+		//
+		// Now, if you get "Events buffer full" warnings, the buffer is too small.
+		//
+		// By this definition, 40 was too small, and 80 was OK.
+		//
+		// Bumped to 160 because of: https://github.com/walles/moor/issues/164
+		events: make(chan Event, 160),
+	}
 
 	screen.setupSigwinchNotification()
 	err := screen.setupTtyInTtyOut()

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -874,9 +874,7 @@ func parseTerminalBgColorResponse(responseBytes []byte) (*Color, bool) {
 		return nil, false // Invalid
 	}
 
-	color := NewColor24Bit(uint8(red/256), uint8(green/256), uint8(blue/256))
-
-	return &color, true // Valid
+	return new(NewColor24Bit(uint8(red/256), uint8(green/256), uint8(blue/256))), true // Valid
 }
 
 func (screen *UnixScreen) SetCell(column int, row int, styledRune StyledRune) int {

--- a/twin/styledRune.go
+++ b/twin/styledRune.go
@@ -2,6 +2,7 @@ package twin
 
 import (
 	"fmt"
+	"slices"
 	"unicode"
 
 	"github.com/rivo/uniseg"
@@ -38,8 +39,7 @@ func (styledRune StyledRune) Equal(other StyledRune) bool {
 
 // Returns a slice of cells with trailing whitespace cells removed
 func TrimSpaceRight(runes []StyledRune) []StyledRune {
-	for i := len(runes) - 1; i >= 0; i-- {
-		cell := runes[i]
+	for i, cell := range slices.Backward(runes) {
 		if !unicode.IsSpace(cell.Rune) {
 			return runes[0 : i+1]
 		}

--- a/twin/styles_test.go
+++ b/twin/styles_test.go
@@ -8,9 +8,7 @@ import (
 )
 
 func TestHyperlinkToNormal(t *testing.T) {
-	url := "http://example.com"
-
-	style := StyleDefault.WithHyperlink(&url)
+	style := StyleDefault.WithHyperlink(new("http://example.com"))
 	assert.Equal(t,
 		strings.ReplaceAll(StyleDefault.RenderUpdateFrom(style, ColorCount16), "\x1b", "ESC"),
 		"ESC]8;;ESC\\")


### PR DESCRIPTION
Go 1.27 bundles Unicode 17.0.0 (up from 15.0.0), so `unicode.IsPrint()`
recognizes all the Unicode blocks added since 15.0 without needing a
manual whitelist. This replaces #408, which can be closed once this
lands.

Also applied a few of `go fix`'s Go 1.26/1.27 modernizers by hand,
verifying and finishing each one manually since the tool alone is
narrower than it looks:

- `new(expr)` (Go 1.26) in place of declaring a local purely to take
  its address, at ~20 sites `go fix` itself didn't catch (its
  `newexpr` analyzer only rewrites named wrapper functions, not the
  much more common inline pattern).
- `slices.Backward` for manual reverse-index loops.
- `go fix`'s `embedlit` rewrite, which folds field assignments into a
  preceding struct literal but stops at the first one it can't safely
  fold; finished the rest by hand in `scrollPosition_test.go` where
  the remaining assignments didn't depend on the struct being
  constructed.

Skipped `go fix`'s `minmax` and `stringsbuilder`/`stringscut`
suggestions after review — they didn't improve readability here.

## Test plan

- [x] `./test.sh` passes

🤖 Written by Claude (Sonnet 5)